### PR TITLE
mysql_service_watcher: created a new mysql service watcher for basic validation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,8 @@ PATH
   specs:
     nerve (0.3.0)
       bunny (= 1.0.0.rc2)
+      mysql2 (= 0.3.14)
+      pg (= 0.17.0)
       zk (~> 1.9.2)
 
 GEM
@@ -14,6 +16,8 @@ GEM
     little-plugger (1.1.3)
     logging (1.7.2)
       little-plugger (>= 1.1.3)
+    mysql2 (0.3.14)
+    pg (0.17.0)
     zk (1.9.2)
       logging (~> 1.7.2)
       zookeeper (~> 1.4.0)

--- a/example/nerve.conf.json
+++ b/example/nerve.conf.json
@@ -45,6 +45,21 @@
           "password": "guest"
         }
       ]
+    },
+    "postgresql_service": {
+      "port": 4321,
+      "host": "127.0.0.1",
+      "zk_hosts": ["localhost:2181"],
+      "zk_path": "/nerve/services/your_postgresql_service/services",
+      "check_interval": 2,
+      "checks": [
+        {
+          "type": "postgresql",
+          "dbname": "dbname",
+          "user": "guest",
+          "password": "guest"
+        }
+      ]
     }
   }
 }

--- a/example/nerve.conf.json
+++ b/example/nerve.conf.json
@@ -60,6 +60,21 @@
           "password": "guest"
         }
       ]
+    },
+    "mysql_service": {
+      "port": 3306,
+      "host": "127.0.0.1",
+      "zk_hosts": ["localhost:2181"],
+      "zk_path": "/nerve/services/your_mysql_service/services",
+      "check_interval": 2,
+      "checks": [
+        {
+          "type": "mysql",
+          "dbname": "dbname",
+          "user": "guest",
+          "password": "guest"
+        }
+      ]
     }
   }
 }

--- a/lib/nerve/service_watcher.rb
+++ b/lib/nerve/service_watcher.rb
@@ -1,6 +1,7 @@
 require 'nerve/service_watcher/tcp'
 require 'nerve/service_watcher/http'
 require 'nerve/service_watcher/rabbitmq'
+require 'nerve/service_watcher/rabbitmq'
 
 module Nerve
   class ServiceWatcher

--- a/lib/nerve/service_watcher.rb
+++ b/lib/nerve/service_watcher.rb
@@ -2,6 +2,7 @@ require 'nerve/service_watcher/tcp'
 require 'nerve/service_watcher/http'
 require 'nerve/service_watcher/rabbitmq'
 require 'nerve/service_watcher/postgresql'
+require 'nerve/service_watcher/mysql'
 
 module Nerve
   class ServiceWatcher

--- a/lib/nerve/service_watcher.rb
+++ b/lib/nerve/service_watcher.rb
@@ -1,7 +1,7 @@
 require 'nerve/service_watcher/tcp'
 require 'nerve/service_watcher/http'
 require 'nerve/service_watcher/rabbitmq'
-require 'nerve/service_watcher/rabbitmq'
+require 'nerve/service_watcher/postgresql'
 
 module Nerve
   class ServiceWatcher

--- a/lib/nerve/service_watcher/mysql.rb
+++ b/lib/nerve/service_watcher/mysql.rb
@@ -1,0 +1,51 @@
+require 'nerve/service_watcher/base'
+require 'mysql'
+
+module Nerve
+  module ServiceCheck
+    class MySQLServiceCheck < BaseServiceCheck
+
+      def initialize(opts={})
+        super
+
+        raise ArgumentError, "missing required arguments in mysql check" unless opts['port'] and opts['user']
+
+        @port = opts['port']
+        @host = opts['host']
+        @dbname = opts['dbname']
+        @user = opts['user']
+        @password = opts['password']
+      end
+
+      def check
+        log.debug "nerve: running @host = opts['host'] health check #{@name}"
+
+        begin
+          conn = Mysql.new(
+            @host, 
+            @user, 
+            @password, 
+            @dbname, 
+            @port
+          )
+
+          res = conn.query 'SELECT VERSION()'
+          data = res.fetch_row
+          if data
+            return true
+          else
+            log.debug "nerve: mysql failed to responde"
+            return false
+          end
+        rescue Mysql:Error => e
+          log.debug "nerve: unable to connect with mysql"
+        ensure
+          conn.close if conn
+        end
+      end
+    end
+
+    CHECKS ||= {}
+    CHECKS['mysql'] = MySQLServiceCheck
+  end
+end

--- a/lib/nerve/service_watcher/mysql.rb
+++ b/lib/nerve/service_watcher/mysql.rb
@@ -8,13 +8,14 @@ module Nerve
       def initialize(opts={})
         super
 
-        raise ArgumentError, "missing required arguments in mysql check" unless opts['port'] and opts['user']
+        %w{port dbname user password}.each do |required|
+          raise ArgumentError, "missing required argument #{required} in mysql check" unless
+            opts[required]
+          instance_variable_set("@#{required}",opts[required])
+        end
 
-        @port = opts['port']
-        @host = opts['host']
-        @dbname = opts['dbname']
-        @user = opts['user']
-        @password = opts['password']
+        @host = opts['host'] || '127.0.0.1'
+        @name = "#{@user}@#{@host}"
       end
 
       def check
@@ -31,14 +32,15 @@ module Nerve
 
           res = conn.query 'SELECT VERSION()'
           data = res.fetch_row
+
           if data
             return true
           else
             log.debug "nerve: mysql failed to responde"
             return false
           end
-        rescue Mysql:Error => e
-          log.debug "nerve: unable to connect with mysql"
+        rescue Mysql::Error => e
+          log.debug "nerve: unable to connect with mysql #{e}"
           return false
         ensure
           conn.close if conn

--- a/lib/nerve/service_watcher/mysql.rb
+++ b/lib/nerve/service_watcher/mysql.rb
@@ -39,6 +39,7 @@ module Nerve
           end
         rescue Mysql:Error => e
           log.debug "nerve: unable to connect with mysql"
+          return false
         ensure
           conn.close if conn
         end

--- a/lib/nerve/service_watcher/postgresql.rb
+++ b/lib/nerve/service_watcher/postgresql.rb
@@ -1,0 +1,52 @@
+require 'nerve/service_watcher/base'
+require 'pg'
+
+module Nerve
+  module ServiceCheck
+    class PostgreSQLServiceCheck < BaseServiceCheck
+      require 'socket'
+      include Socket::Constants
+
+      def initialize(opts={})
+        super
+
+        raise ArgumentError, "missing required arguments in postgresql check" unless opts['port'] and opts['user']
+
+        @port = opts['port']
+        @host = opts['host']
+        @dbname = opts['dbname']
+        @user = opts['user']
+        @password = opts['password']
+      end
+
+      def check
+        # The best way to check postgresql is alive to query
+        log.debug "nerve: running @host = opts['host'] health check #{@name}"
+
+        conn = PGconn.new(
+          :host => @host,
+          :port => @port,
+          :dbname => @dbname,
+          :user => @user,
+          :password => @password
+        )
+
+        begin
+          res = conn.exec('select 1')
+          data = res.getvalue(0,0)
+          if data
+            return true
+          else
+            log.debug "nerve: postgresql failed to responde"
+            return false
+          end
+        ensure
+          conn.close
+        end
+      end
+    end
+
+    CHECKS ||= {}
+    CHECKS['postgresql'] = PostgreSQLServiceCheck
+  end
+end

--- a/lib/nerve/service_watcher/postgresql.rb
+++ b/lib/nerve/service_watcher/postgresql.rb
@@ -4,8 +4,6 @@ require 'pg'
 module Nerve
   module ServiceCheck
     class PostgreSQLServiceCheck < BaseServiceCheck
-      require 'socket'
-      include Socket::Constants
 
       def initialize(opts={})
         super

--- a/nerve.gemspec
+++ b/nerve.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency "zk", "~> 1.9.2"
   gem.add_runtime_dependency "bunny", "= 1.0.0.rc2"
+  gem.add_runtime_dependency "pg", "= 0.17.0"
 end

--- a/nerve.gemspec
+++ b/nerve.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "zk", "~> 1.9.2"
   gem.add_runtime_dependency "bunny", "= 1.0.0.rc2"
   gem.add_runtime_dependency "pg", "= 0.17.0"
+  gem.add_runtime_dependency "mysql2", "= 0.3.14"
 end


### PR DESCRIPTION
There is a new dependency for postgresql so need to execute `bundle install` in nerve environment, if installation fails install `sudo apt-get install libpq-dev` and then re-install gem

There is a new dependency for mysql so need to execute `bundle install` in nerve environment, if installation fails install `sudo apt-get install libmysql-ruby libmysqlclient-dev` and then re-install gem

For more details:
[How to use ruby environment for Nerve and Synapse](https://github.com/dubizzle/smartstack-cookbook/wiki/How-to-use-ruby-environment-for-Nerve-and-Synapse)
