### PR TITLE
stop nerve when one of the watchers raises an exception, this will cause...

### DIFF
--- a/lib/nerve.rb
+++ b/lib/nerve.rb
@@ -42,9 +42,12 @@ module Nerve
 
       begin
         sleep
-      rescue
-        log.debug 'nerve: sleep interrupted; exiting'
+      rescue StandardError => e
+        log.error 'nerve: encountered unexpected exception #{e.inspect} in main thread'
+        raise e
+      ensure
         $EXIT = true
+        log.warn 'nerve: reaping all watchers'
         @watchers.each do |name, watcher_thread|
           reap_watcher(name)
         end


### PR DESCRIPTION
... nerve to restart https://github.com/airbnb/nerve/pull/37  https://github.com/airbnb/nerve/issues/34

@qasimkhan @dcrasto 
